### PR TITLE
feat(cookiecutter/urls): root redirect to 'api-root'

### DIFF
--- a/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/config/common.py
+++ b/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/config/common.py
@@ -91,6 +91,7 @@ class Common(Configuration):
     USE_I18N = True
     USE_L10N = True
     USE_TZ = True
+    LOGIN_REDIRECT_URL = '/'
 
     # Static Files
     STATIC_ROOT = join(os.path.dirname(BASE_DIR), 'staticfiles')

--- a/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/urls.py
+++ b/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/urls.py
@@ -2,13 +2,19 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django.conf.urls import include, url
+from django.core.urlresolvers import reverse_lazy
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.views.generic.base import RedirectView
 
 urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^api/v1/', include('authentication.urls')),
     url(r'^api/v1/', include('users.urls')),
     url(r'^api/v1/notifications/', include('push_notifications.urls')),
+
+    # the 'api-root' from django rest-frameworks default router
+    # http://www.django-rest-framework.org/api-guide/routers/#defaultrouter
+    url(r'^$', RedirectView.as_view(url=reverse_lazy('api-root'))),
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Closes #7 for release #4 
