### PR TITLE
chore(requirements/base): upgraded django-pnm to 0.1.6

### DIFF
--- a/{{cookiecutter.github_repository_name}}/requirements/base.txt
+++ b/{{cookiecutter.github_repository_name}}/requirements/base.txt
@@ -28,7 +28,7 @@ boto==2.38.0
 django-versatileimagefield==1.0.2
 
 # push notifications
-django-pnm==0.1.5
+django-pnm==0.1.6
 
 # For asynchronous queuing
 django-rq==0.8.0


### PR DESCRIPTION
closes #86 for release #4 
