### PR TITLE
chore(cookicutter/urls): updated api-root redirect view

### DIFF
--- a/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/urls.py
+++ b/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/urls.py
@@ -21,6 +21,6 @@ urlpatterns = [
 
     # the 'api-root' from django rest-frameworks default router
     # http://www.django-rest-framework.org/api-guide/routers/#defaultrouter
-    url(r'^$', RedirectView.as_view(url=reverse_lazy('api-root'))),
+    url(r'^$', RedirectView.as_view(url=reverse_lazy('api-root'), permanent=True)),
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Closes #90 for release #4 
