### PR TITLE
Python 3 support

### DIFF
--- a/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/config/production.py
+++ b/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/config/production.py
@@ -1,8 +1,15 @@
 import os
-import urlparse
 from configurations import values
 from boto.s3.connection import OrdinaryCallingFormat
 from .common import Common
+
+try:
+    # Python 2.x
+    import urlparse
+except ImportError:
+    # Python 3.x
+    from urllib import parse as urlparse
+
 
 class Production(Common):
 


### PR DESCRIPTION
The `urlparse` has been renamed in Python 3. See http://python3porting.com/stdlib.html#urllib-urllib2-and-urlparse
