### PR TITLE
feat(cookiecutter.app_name/urls): Changed permanent=True to False to …

### DIFF
--- a/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/urls.py
+++ b/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/urls.py
@@ -21,6 +21,6 @@ urlpatterns = [
 
     # the 'api-root' from django rest-frameworks default router
     # http://www.django-rest-framework.org/api-guide/routers/#defaultrouter
-    url(r'^$', RedirectView.as_view(url=reverse_lazy('api-root'), permanent=True)),
+    url(r'^$', RedirectView.as_view(url=reverse_lazy('api-root'), permanent=False)),
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
…prevent permanent redirects from browsers
## Issue

While having used this cookiecutter for a while now I have used the redirect to `api/v1`, but now my problem is the following: Now I have a MKDocs page which I served through `mkdocs serve`, but because the option on the `urls.py` of the project to `api/v1` was permanent, my Google Chrome has decided to cache this option.

Now I'm unable to get to my docs serve with mkdocs, the only possibility is to clear my history, so I think it is better to set this to `False`, what do you guys think?
