### PR TITLE
use factory boy fake wrapper

### DIFF
--- a/{{cookiecutter.github_repository_name}}/requirements/test.txt
+++ b/{{cookiecutter.github_repository_name}}/requirements/test.txt
@@ -5,8 +5,7 @@
 mock==1.3.0
 
 # Fixtures
-factory-boy==2.5.2
-fake-factory==0.5.2
+factory-boy==2.6.0
 
 # Test Runner
 django-nose==1.4.1

--- a/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/users/test/factories.py
+++ b/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/users/test/factories.py
@@ -1,7 +1,4 @@
 import factory
-from faker import Faker
-
-fake = Faker()
 
 
 class UserFactory(factory.django.DjangoModelFactory):
@@ -11,9 +8,9 @@ class UserFactory(factory.django.DjangoModelFactory):
         django_get_or_create = ('username',)
 
     username = factory.Sequence(lambda n: 'testuser{}'.format(n))
-    password = fake.password(length=10, special_chars=True, digits=True, upper_case=True, lower_case=True)
-    email = fake.email()
-    first_name = fake.first_name()
-    last_name = fake.last_name()
+    password = factory.Faker('password', length=10, special_chars=True, digits=True, upper_case=True, lower_case=True)
+    email = factory.Faker('email')
+    first_name = factory.Faker('first_name')
+    last_name = factory.Faker('last_name')
     is_active = True
     is_staff = False

--- a/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/users/test/test_serializers.py
+++ b/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/users/test/test_serializers.py
@@ -2,11 +2,8 @@ from django.test import TestCase
 from django.forms.models import model_to_dict
 from django.contrib.auth.hashers import check_password
 from nose.tools import eq_, ok_
-from faker import Faker
 from .factories import UserFactory
 from ..serializers import CreateUserSerializer
-
-fake = Faker()
 
 
 class TestCreateUserSerializer(TestCase):


### PR DESCRIPTION
The way things are in master now, if I write a test that creates two users like so:

``` python
user1 = UserFactory()
user2 = UserFactory()
```

both users will have the same `first_name`, `last_name`, etc. This PR upgrades `factory-boy` to 2.6.0 and uses the new built-in `fake-factory` wrappers to eliminate the duplicating data. I also removed the unused `fake-factory` import from `test_serializers`.
