### PR TITLE
add security middleware

### DIFF
--- a/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/config/common.py
+++ b/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/config/common.py
@@ -38,6 +38,7 @@ class Common(Configuration):
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
+        'django.middleware.security.SecurityMiddleware'
     )
 
     ROOT_URLCONF = 'urls'


### PR DESCRIPTION
Hi Andrew,
Just noticed this one when I pushed to production and the `SECURE_SSL_REDIRECT` wasn't working. I added the security middleware in `common.py` and it works well in production without causing problems locally.
