### PR TITLE
feat(config/production): let boto not add the Signature and Key to th…

### DIFF
--- a/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/config/production.py
+++ b/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/config/production.py
@@ -56,6 +56,7 @@ class Production(Common):
     AWS_SECRET_ACCESS_KEY = values.Value('DJANGO_AWS_SECRET_ACCESS_KEY')
     AWS_STORAGE_BUCKET_NAME = values.Value('DJANGO_AWS_STORAGE_BUCKET_NAME')
     AWS_AUTO_CREATE_BUCKET = True
+    AWS_QUERYSTRING_AUTH = False
     MEDIA_URL = 'https://s3.amazonaws.com/{}/'.format(AWS_STORAGE_BUCKET_NAME)
     AWS_S3_CALLING_FORMAT = OrdinaryCallingFormat()
 


### PR DESCRIPTION
…e static files.
## Current problem

The current problem that I'm occurring is that we have people request an image for example. These get back an image and retrieve it correctly. The only problem is that there is also a `Signature` and `AccessKeyId` in their image URL. This prevents them from caching the images because of the change in the Signature because of the hashing.

Example response for an image (versatile image field that works with storages of django).

```
https://s3.amazonaws.com/bucket/image.jpg?Signature=tOw7H9HHDieH5Bw4f3cOmE%3D&Expires=1454587616&AWSAccessKeyId=ACCESS_KEY
```

This prevents it from adding it, the only downside is that the user needs to have set the bucket for Everyone to View
