### PR TITLE
Small updates to docs/users.md to reflect current API

### DIFF
--- a/{{cookiecutter.github_repository_name}}/docs/api/users.md
+++ b/{{cookiecutter.github_repository_name}}/docs/api/users.md
@@ -12,15 +12,13 @@ Parameters:
 Name     | Type   | Description
 ---------|--------|---
 username | string | The username for the new user.
-password | string | The password for the new user (plaintext).
+password | string | The password for the new user.
 
 *Note:*
 
 - *Not* **Authorization Protected**
 
-
 **Response**:
-If a User with given `username` doesn't exist, you'll get a 201:
 
 ```json
 Content-Type application/json
@@ -34,18 +32,8 @@ Content-Type application/json
 }
 ```
 
-else if the `username` is already taken, you'll get a 400:
-
-```json
-Content-Type application/json
-400 Bad Request
-
-{
-    "username": [
-        "A user with that username already exists."
-    ]
-}
-```
+The `auth_token` returned with this response should be stored by the client for
+authenticating future requests to the API. See [Authentication](authentication.md).
 
 
 ## Get a user's profile information
@@ -55,11 +43,6 @@ Content-Type application/json
 `GET` `users/:id`
 
 Parameters:
-
-Name | Type   | Description
------|--------|---
-id   | string | The id associated with the user object.
-
 
 *Note:*
 
@@ -88,10 +71,10 @@ Content-Type application/json
 
 Parameters:
 
-Name | Type | Description
----|---|---
+Name       | Type   | Description
+-----------|--------|---
 first_name | string | The new first_name of the user object.
-last_name | string | The new last_name of the user object.
+last_name  | string | The new last_name of the user object.
 
 
 *Note:*

--- a/{{cookiecutter.github_repository_name}}/docs/api/users.md
+++ b/{{cookiecutter.github_repository_name}}/docs/api/users.md
@@ -7,25 +7,47 @@ Supports registering, viewing, and updating user accounts.
 
 `POST` `users/`
 
+Parameters:
+
+Name     | Type   | Description
+---------|--------|---
+username | string | The username for the new user.
+password | string | The password for the new user (plaintext).
+
 *Note:*
 
 - *Not* **Authorization Protected**
 
 
 **Response**:
+If a User with given `username` doesn't exist, you'll get a 201:
 
 ```json
 Content-Type application/json
 201 Created
 
 {
-  "id": 1,
-  "first_name": "Richard",
-  "last_name": "Hendriks",
-  "auth_token": "fFBGRNJru1FQd44AzqT3Zg",
-  "email": "hendriks@piepiper.com"
+  "id": "6d5f9bae-a31b-4b7b-82c4-3853eda2b011",
+  "username": "richard",
+  "password": "pbkdf2_sha256$24000$aGozcCr6QXhv$WCgPt2voqVO+Nno2flVnNnLcfks6Yq8XJyxoadB/r50=",
+  "auth_token": "132cf952e0165a274bf99e115ab483671b3d9ff6"
 }
 ```
+
+else if the `username` is already taken, you'll get a 400:
+
+```json
+Content-Type application/json
+400 Bad Request
+
+{
+    "username": [
+        "A user with that username already exists."
+    ]
+}
+```
+
+
 ## Get a user's profile information
 
 **Request**:
@@ -34,9 +56,9 @@ Content-Type application/json
 
 Parameters:
 
-Name | Type | Description
----|---|---
-id | integer | The id associated with the user object.
+Name | Type   | Description
+-----|--------|---
+id   | string | The id associated with the user object.
 
 
 *Note:*
@@ -50,45 +72,13 @@ Content-Type application/json
 200 OK
 
 {
-  "id": 1,
+  "id": "6d5f9bae-a31b-4b7b-82c4-3853eda2b011",
+  "username": "richard",
   "first_name": "Richard",
-  "last_name": "Hendriks",
-  "auth_token": "fFBGRNJru1FQd44AzqT3Zg",
-  "email": "hendriks@piepiper.com"
+  "last_name": "Hendriks"
 }
 ```
 
-## Get a user's profile information
-
-**Request**:
-
-`GET` `users/:id`
-
-Parameters:
-
-Name | Type | Description
----|---|---
-id | integer | The id associated with the user object.
-
-
-*Note:*
-
-- **[Authorization Protected](authentication.md)**
-
-**Response**:
-
-```json
-Content-Type application/json
-200 OK
-
-{
-  "id": 1,
-  "first_name": "Richard",
-  "last_name": "Hendriks",
-  "auth_token": "fFBGRNJru1FQd44AzqT3Zg",
-  "email": "hendriks@piepiper.com"
-}
-```
 
 ## Update your profile information
 
@@ -102,7 +92,6 @@ Name | Type | Description
 ---|---|---
 first_name | string | The new first_name of the user object.
 last_name | string | The new last_name of the user object.
-email | string | The new email of the user object.
 
 
 *Note:*
@@ -117,10 +106,9 @@ Content-Type application/json
 200 OK
 
 {
-  "id": 1,
+  "id": "6d5f9bae-a31b-4b7b-82c4-3853eda2b011",
+  "username": "richard",
   "first_name": "Richard",
-  "last_name": "Hendriks",
-  "auth_token": "fFBGRNJru1FQd44AzqT3Zg",
-  "email": "hendriks@piepiper.com"
+  "last_name": "Hendriks"
 }
 ```

--- a/{{cookiecutter.github_repository_name}}/docs/api/users.md
+++ b/{{cookiecutter.github_repository_name}}/docs/api/users.md
@@ -5,7 +5,7 @@ Supports registering, viewing, and updating user accounts.
 
 **Request**:
 
-`POST` `users/`
+`POST` `/users/`
 
 Parameters:
 
@@ -40,7 +40,7 @@ authenticating future requests to the API. See [Authentication](authentication.m
 
 **Request**:
 
-`GET` `users/:id`
+`GET` `/users/:id`
 
 Parameters:
 
@@ -67,7 +67,7 @@ Content-Type application/json
 
 **Request**:
 
-`PUT/PATCH` `users/:id`
+`PUT/PATCH` `/users/:id`
 
 Parameters:
 


### PR DESCRIPTION
It seems like email is not exposed anymore.

Also auth_token is available only on initial post to /users/ (during user registration).

Not sure of docs format --- how do you distinguish between URL params, query string params, and POST data?
