### PR TITLE
Delete a comment in user permissions

### DIFF
--- a/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/users/permissions.py
+++ b/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/users/permissions.py
@@ -4,7 +4,6 @@ from rest_framework import permissions
 class IsOwnerOrReadOnly(permissions.BasePermission):
     """
     Object-level permission to only allow owners of an object to edit it.
-    Assumes the model instance has an `owner` attribute.
     """
 
     def has_object_permission(self, request, view, obj):


### PR DESCRIPTION
Closes #178 for release #167.

We don't assume the model instance has an `owner` attribute, which is confusing.
