### PR TITLE
Update serializers.py

### DIFF
--- a/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/users/serializers.py
+++ b/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/users/serializers.py
@@ -23,4 +23,4 @@ class CreateUserSerializer(serializers.ModelSerializer):
         model = User
         fields = ('id', 'username', 'password', 'auth_token')
         read_only_fields = ('auth_token',)
-        write_only_fields = ('password',)
+        extra_kwargs = {'password': {'write_only': True}}


### PR DESCRIPTION
The write_only_fields does not work any more. Change the format of write_only_field according to the official docs http://www.django-rest-framework.org/api-guide/serializers/#additional-keyword-arguments
