### PR TITLE
Fix templates paths

### DIFF
--- a/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/config/common.py
+++ b/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/config/common.py
@@ -82,7 +82,7 @@ class Common(Configuration):
     TEMPLATES = [
         {
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
-            'DIRS': [STATICFILES_DIRS],
+            'DIRS': STATICFILES_DIRS,
             'OPTIONS': {
                 'context_processors': [
                     'django.contrib.auth.context_processors.auth',


### PR DESCRIPTION
STATICFILES_DIRS = [join(os.path.dirname(BASE_DIR), 'static'), ] - is a list
'DIRS' should be STATICFILES_DIRS, rather than [STATICFILES_DIRS]. If 'DIRS' == [STATICFILES_DIRS] then DIRS is a list of list of dirs rather than list of dirs