### PR TITLE
chore(requirements/base): upgrade django after vulnerablity

### DIFF
--- a/{{cookiecutter.github_repository_name}}/requirements/base.txt
+++ b/{{cookiecutter.github_repository_name}}/requirements/base.txt
@@ -1,5 +1,5 @@
 # Django
-Django==1.10.6
+Django==1.10.7
 
 # Environmental var configuration
 django-configurations==2.0


### PR DESCRIPTION
Closes #403  for release #327.
