### PR TITLE
Fix(readme): add django configuration settings to heroku

### DIFF
--- a/{{cookiecutter.github_repository_name}}/README.md
+++ b/{{cookiecutter.github_repository_name}}/README.md
@@ -34,7 +34,7 @@ Initialize the production server:
 heroku create {{cookiecutter.app_name}}-prod --remote prod && \
     heroku addons:create newrelic:wayne --app {{cookiecutter.app_name}}-prod && \
     heroku addons:create heroku-postgresql:hobby-dev --app {{cookiecutter.app_name}}-prod && \
-    heroku config:set DJANGO_SECRET=`openssl rand -base64 32` \
+    heroku config:set DJANGO_SECRET_KEY=`openssl rand -base64 32` \
         DJANGO_AWS_ACCESS_KEY_ID="Add your id" \
         DJANGO_AWS_SECRET_ACCESS_KEY="Add your key" \
         DJANGO_AWS_STORAGE_BUCKET_NAME="{{cookiecutter.app_name}}-prod" \
@@ -47,7 +47,7 @@ Initialize the qa server:
 heroku create {{cookiecutter.app_name}}-qa --remote qa && \
     heroku addons:create newrelic:wayne --app {{cookiecutter.app_name}}-qa && \
     heroku addons:create heroku-postgresql:hobby-dev --app {{cookiecutter.app_name}}-qa && \
-    heroku config:set DJANGO_SECRET=`openssl rand -base64 32` \
+    heroku config:set DJANGO_SECRET_KEY=`openssl rand -base64 32` \
         DJANGO_AWS_ACCESS_KEY_ID="Add your id" \
         DJANGO_AWS_SECRET_ACCESS_KEY="Add your key" \
         DJANGO_AWS_STORAGE_BUCKET_NAME="{{cookiecutter.app_name}}-qa" \

--- a/{{cookiecutter.github_repository_name}}/README.md
+++ b/{{cookiecutter.github_repository_name}}/README.md
@@ -38,6 +38,8 @@ heroku create {{cookiecutter.app_name}}-prod --remote prod && \
         DJANGO_AWS_ACCESS_KEY_ID="Add your id" \
         DJANGO_AWS_SECRET_ACCESS_KEY="Add your key" \
         DJANGO_AWS_STORAGE_BUCKET_NAME="{{cookiecutter.app_name}}-prod" \
+        DJANGO_CONFIGURATION="Production" \
+        DJANGO_SETTINGS_MODULE="{{cookiecutter.app_name}}.config" \
         --app {{cookiecutter.app_name}}-prod
 ```
 
@@ -51,6 +53,8 @@ heroku create {{cookiecutter.app_name}}-qa --remote qa && \
         DJANGO_AWS_ACCESS_KEY_ID="Add your id" \
         DJANGO_AWS_SECRET_ACCESS_KEY="Add your key" \
         DJANGO_AWS_STORAGE_BUCKET_NAME="{{cookiecutter.app_name}}-qa" \
+        DJANGO_CONFIGURATION="Production" \
+        DJANGO_SETTINGS_MODULE="{{cookiecutter.app_name}}.config" \
         --app {{cookiecutter.app_name}}-qa
 ```
 

--- a/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/config/production.py
+++ b/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/config/production.py
@@ -14,7 +14,7 @@ class Production(Common):
     # https://docs.djangoproject.com/en/2.0/howto/static-files/
     # http://django-storages.readthedocs.org/en/latest/index.html
     INSTALLED_APPS += ('storages',)
-    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3BotoStorage'
+    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
     STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
     AWS_ACCESS_KEY_ID = os.getenv('DJANGO_AWS_ACCESS_KEY_ID')
     AWS_SECRET_ACCESS_KEY = os.getenv('DJANGO_AWS_SECRET_ACCESS_KEY')


### PR DESCRIPTION
Specifies the production configuration by adding the corresponding environmental variables to Heroku. While this is already taken care of by the defaults set in `wsgi.py`, its needed for `collectstatic` to work correctly on deploys.

May solve #533  for release #508 .
