### PR TITLE
feat(cookiecutter/docker-compose): ensure postgres is ready 

### DIFF
--- a/{{cookiecutter.github_repository_name}}/docker-compose.yml
+++ b/{{cookiecutter.github_repository_name}}/docker-compose.yml
@@ -10,7 +10,8 @@ services:
     image: web
     build: ./
     command: >
-      bash -c "./manage.py migrate &&
+      bash -c "python wait_for_postgres.py &&
+               ./manage.py migrate &&
                ./manage.py runserver 0.0.0.0:8000"
     volumes:
       - ./:/code


### PR DESCRIPTION
Leverages `wait_for_postgres` to ensure that the database is ready for connections before local development server is started. 