### PR TITLE
Update psycopg2 dependency to psycopg2-binary

### DIFF
--- a/{{cookiecutter.github_repository_name}}/requirements.txt
+++ b/{{cookiecutter.github_repository_name}}/requirements.txt
@@ -6,7 +6,7 @@ gunicorn==19.7.1
 newrelic==3.2.0.91
 
 # For the persistence stores
-psycopg2==2.7.4
+psycopg2-binary==2.7.4
 dj-database-url==0.5.0
 
 # Model Tools


### PR DESCRIPTION
Fixes a deprecation warning by using `psycopg2-binary` instead of `psycopg2`:

>UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.