### PR TITLE
Add Mailhog to catch emails

### DIFF
--- a/{{cookiecutter.github_repository_name}}/docker-compose.yml
+++ b/{{cookiecutter.github_repository_name}}/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - "8000:8000"
     depends_on:
       - postgres
+      - mailhog
   documentation:
     restart: always
     build: ./
@@ -27,3 +28,8 @@ services:
       - ./:/code
     ports:
       - "8001:8001"
+  mailhog:
+    restart: always
+    image: mailhog/mailhog:v1.0.0
+    ports:
+      - 8025:8025

--- a/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/config/local.py
+++ b/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/config/local.py
@@ -20,6 +20,6 @@ class Local(Common):
     ]
 
     # Mail
-    EMAIL_HOST = 'localhost'
+    EMAIL_HOST = 'mailhog'
     EMAIL_PORT = 1025
-    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+    EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'


### PR DESCRIPTION
Add Mailhog container to catch emails sent by the backend. The users can always check the email at 0.0.0.0:8025 from any webbrowsers.
