### PR TITLE
Update UserFactory id field to use uuid

### DIFF
--- a/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/users/test/factories.py
+++ b/{{cookiecutter.github_repository_name}}/{{cookiecutter.app_name}}/users/test/factories.py
@@ -1,4 +1,5 @@
 import factory
+import uuid
 
 
 class UserFactory(factory.django.DjangoModelFactory):
@@ -7,7 +8,7 @@ class UserFactory(factory.django.DjangoModelFactory):
         model = 'users.User'
         django_get_or_create = ('username',)
 
-    id = factory.Faker('uuid4')
+    id = factory.LazyFunction(uuid.uuid4)
     username = factory.Sequence(lambda n: f'testuser{n}')
     password = factory.Faker('password', length=10, special_chars=True, digits=True,
                              upper_case=True, lower_case=True)


### PR DESCRIPTION
Updates UserFactory id field to use `uuid.uuid4` instead of the `uuid` from Faker.

This ensures that the type of the id generated by the factory is the same as the actual user instance:

```pycon
>>> user = UserFactory()
>>> type(user.id)
uuid.UUID
```

Currently, the type is a string.